### PR TITLE
[1.0.x] Removed the unnecessary description for escaping of wildcard search in DataAccessCommon.rst. #713

### DIFF
--- a/source/ArchitectureInDetail/DataAccessCommon.rst
+++ b/source/ArchitectureInDetail/DataAccessCommon.rst
@@ -751,8 +751,7 @@ LIKE検索時のエスケープについて
 
 共通ライブラリから提供しているエスケープ用のメソッドについて
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-| 共通ライブラリから提供している\ ``QueryEscapeUtils``\ クラスのエスケープ用メソッドの一覧を、以下に示す。
-| 具体的な使用例については、How to useの\ :ref:`data-access-common_howtouse_like_escape`\ を参照されたい。
+共通ライブラリから提供している\ ``QueryEscapeUtils``\ クラスのエスケープ用メソッドの一覧を、以下に示す。
 
  .. tabularcolumns:: |p{0.10\linewidth}|p{0.35\linewidth}|p{0.55\linewidth}|
  .. list-table::

--- a/source_en/ArchitectureInDetail/DataAccessCommon.rst
+++ b/source_en/ArchitectureInDetail/DataAccessCommon.rst
@@ -751,8 +751,7 @@ See the example of escaping below.
 
 About escaping methods provided by common library
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-| List of escaping methods of \ ``QueryEscapeUtils``\  class provided by common library is given below.
-| For usage example, refer to \ :ref:`data-access-common_howtouse_like_escape`\  of How to use.
+List of escaping methods of \ ``QueryEscapeUtils``\  class provided by common library is given below.
 
  .. tabularcolumns:: |p{0.10\linewidth}|p{0.35\linewidth}|p{0.55\linewidth}|
  .. list-table::


### PR DESCRIPTION
Backported to 1.0.x from Please review  #714 .
Please review #713 .