### PR TITLE
[1.0.x] Modified meta tag's name for CSRF in Ajax.rst. #680

### DIFF
--- a/source/ArchitectureInDetail/Ajax.rst
+++ b/source/ArchitectureInDetail/Ajax.rst
@@ -585,8 +585,8 @@ Ajaxを使ってフォームのデータをPOSTし、処理結果を取得する
 
     <meta name="contextPath" content="${pageContext.request.contextPath}" />
 
-    <meta name="_csrf_token" content="${_csrf.token}" />
-    <meta name="_csrf_headerName" content="${_csrf.headerName}" />
+    <meta name="_csrf" content="${_csrf.token}" />
+    <meta name="_csrf_header" content="${_csrf.headerName}" />
 
     <!-- omitted -->
 

--- a/source/ArchitectureInDetail/Ajax.rst
+++ b/source/ArchitectureInDetail/Ajax.rst
@@ -620,8 +620,8 @@ Ajaxを使ってフォームのデータをPOSTし、処理結果を取得する
     var contextPath = $("meta[name='contextPath']").attr("content");
 
     // (9)
-    var csrfToken = $("meta[name='_csrf_token']").attr("content");
-    var csrfHeaderName = $("meta[name='_csrf_headerName']").attr("content");
+    var csrfToken = $("meta[name='_csrf']").attr("content");
+    var csrfHeaderName = $("meta[name='_csrf_header']").attr("content");
     $(document).ajaxSend(function(event, xhr, options) {
         xhr.setRequestHeader(csrfHeaderName, csrfToken);
     });

--- a/source_en/ArchitectureInDetail/Ajax.rst
+++ b/source_en/ArchitectureInDetail/Ajax.rst
@@ -619,8 +619,8 @@ Following example is about the Ajax communication of receiving two numbers and r
     var contextPath = $("meta[name='contextPath']").attr("content");
 
     // (9)
-    var csrfToken = $("meta[name='_csrf_token']").attr("content");
-    var csrfHeaderName = $("meta[name='_csrf_headerName']").attr("content");
+    var csrfToken = $("meta[name='_csrf']").attr("content");
+    var csrfHeaderName = $("meta[name='_csrf_header']").attr("content");
     $(document).ajaxSend(function(event, xhr, options) {
         xhr.setRequestHeader(csrfHeaderName, csrfToken);
     });


### PR DESCRIPTION
cherry-picked from #739 .

英語版の `<meta>` タグの修正は別issueで行います。一部masterの内容が取り込まれてしまっているので、それを直す時に一緒に修正します。
確認お願いします。 #680 