### PR TITLE
[1.0.x en] Modified meta tag's name for CSRF in Ajax.rst. #680

### DIFF
--- a/source_en/ArchitectureInDetail/Ajax.rst
+++ b/source_en/ArchitectureInDetail/Ajax.rst
@@ -585,8 +585,8 @@ Following example is about the Ajax communication of receiving two numbers and r
 
     <meta name="contextPath" content="${pageContext.request.contextPath}" />
 
-    <meta name="_csrf_token" content="${_csrf.token}" />
-    <meta name="_csrf_headerName" content="${_csrf.headerName}" />
+    <meta name="_csrf" content="${_csrf.token}" />
+    <meta name="_csrf_header" content="${_csrf.headerName}" />
 
     <!-- omitted -->
 

--- a/source_en/ArchitectureInDetail/Ajax.rst
+++ b/source_en/ArchitectureInDetail/Ajax.rst
@@ -585,7 +585,8 @@ Following example is about the Ajax communication of receiving two numbers and r
 
     <meta name="contextPath" content="${pageContext.request.contextPath}" />
 
-    <sec:csrfMetaTags />
+    <meta name="_csrf_token" content="${_csrf.token}" />
+    <meta name="_csrf_headerName" content="${_csrf.headerName}" />
 
     <!-- omitted -->
 
@@ -713,7 +714,7 @@ Following example is about the Ajax communication of receiving two numbers and r
  .. tip::
 
     In the above example, JSP code is deleted from JavaScript code by setting CSRF token value and CSRF token header name,
-    in the ``<meta>`` element of HTML using \ ``<sec:csrfMetaTags />``\ . Please refer, \ :ref:`csrf_ajax-token-setting`\ .
+    in the ``<meta>`` element of HTML. Please refer, \ :ref:`csrf_ajax-token-setting`\ .
 
     Please note that, CSRF token value and name of CSRF token header can also be fetched by using  \ ``${_csrf.token}``\  and  \ ``${_csrf.headerName}``\  respectively.
 


### PR DESCRIPTION
Reverted description of  spring security 3.2(`<sec:csrfMetaTag>`) and applied meta tag's name of CSRF.
Please review #680 .