### PR TITLE
[1.0.x] Modify wrong explanation of CVE-2014-0050. #846

### DIFF
--- a/source/ArchitectureInDetail/FileUpload.rst
+++ b/source/ArchitectureInDetail/FileUpload.rst
@@ -1730,7 +1730,7 @@ Commons FileUploadを使用する場合は以下の設定を行う。
     \ `CVE-2014-0050 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0050>`_\で報告されているセキュリティの脆弱性が発生する可能性がある。
     使用するApache Commons FileUploadのバージョンに脆弱性がない事を確認されたい。
 
-    Apache Commons FileUploadを使用する場合、1.2系は1.2.1以上、1.3系は1.3.1以上を使用する必要がある。
+    Apache Commons FileUploadを使用する場合、1.3.1以上を使用する必要がある。
 
 |
 

--- a/source_en/ArchitectureInDetail/FileUpload.rst
+++ b/source_en/ArchitectureInDetail/FileUpload.rst
@@ -119,7 +119,7 @@ Classes provided by Spring Web for uploading a file are as follows:
     When using Apache Commons FileUpload, vulnerabilities of security mentioned in \ `CVE-2014-0050 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0050>`_\  may occur.
     Ensure that there are no such vulnerabilities in the Apache Commons FileUpload version to be used.
      
-    When using Apache Commons FileUpload, version 1.2.1 or above of the 1.2 series and 1.3.1 or above of the 1.3 series should be used.
+    When using Apache Commons FileUpload, version 1.3.1 or above should be used.
     
 |
 


### PR DESCRIPTION
(cherry picked from commit e184f0a7b1a984d34318b6799fe4edaac37dfc2d)

Backport to 1.0.x.
Please review #846 .