### PR TITLE
[5.0.x] #941: Modify typo in DataAccessJpa.rst

### DIFF
--- a/source_en/ArchitectureInDetail/DataAccessJpa.rst
+++ b/source_en/ArchitectureInDetail/DataAccessJpa.rst
@@ -610,7 +610,7 @@ Considering the following perspectives, it is recommended that you use Lazy Fetc
 
 See the example of ``OpenEntityManagerInViewInterceptor`` settings below.
 
-- spring-vmc.xml
+- spring-mvc.xml
 
  .. code-block:: xml
 


### PR DESCRIPTION
(cherry picked from commit d6aa6c82fd160cd425b8d719e94af8d50111a5e4)

Backported to 5.0.x.
Please review #941 .