### PR TITLE
fix guideline. #1074

### DIFF
--- a/source/ArchitectureInDetail/Utilities/Dozer.rst
+++ b/source/ArchitectureInDetail/Utilities/Dozer.rst
@@ -1393,7 +1393,7 @@ map-idを指定しない場合はこの設定は適用されず、全フィー�
     destination2.setId(2);
     destination2.setName("DestinationName");
     destination2.setTitle("DestinationTitle");
-    beanMapper.map(source, destination2, "mapidSourceBeanFieldExclude"); // (2)
+    beanMapper.map(source, destination2, "mapidTitleFieldExclude"); // (2)
     System.out.println(destination2.getId());
     System.out.println(destination2.getName());
     System.out.println(destination2.getTitle());

--- a/source_en/ArchitectureInDetail/Utilities/Dozer.rst
+++ b/source_en/ArchitectureInDetail/Utilities/Dozer.rst
@@ -1393,7 +1393,7 @@ The example of passing map-id to ``map`` method is shown below.
     destination2.setId(2);
     destination2.setName("DestinationName");
     destination2.setTitle("DestinationTitle");
-    beanMapper.map(source, destination2, "mapidSourceBeanFieldExclude"); // (2)
+    beanMapper.map(source, destination2, "mapidTitleFieldExclude"); // (2)
     System.out.println(destination2.getId());
     System.out.println(destination2.getName());
     System.out.println(destination2.getTitle());


### PR DESCRIPTION
定義名誤りを修正しました、確認をお願いします。5.0.x系へのバックポートです。
(cherry picked from commit b8e768a1643f3224be04dbc7d16cb198c49e8253)