### PR TITLE
fix typo about session-management #940

### DIFF
--- a/source/Security/Authentication.rst
+++ b/source/Security/Authentication.rst
@@ -888,7 +888,6 @@ Concurrent Session Controlを利用する場合は、
             error-if-maximum-exceeded="true"
             max-sessions="2"
             expired-url="/expiredSessionError.jsp" /><!-- 属性の指定順番で(1)～(3) -->
-        </sec:session-management>
     </sec:session-management>
   </sec:http>
 


### PR DESCRIPTION
session-managementの閉じタグが二つあったので、不要な一つを削除。
ご確認をお願いいたします。 #940