### PR TITLE
fix typo about framework stack #976

### DIFF
--- a/source/Overview/FrameworkStack.rst
+++ b/source/Overview/FrameworkStack.rst
@@ -476,13 +476,13 @@ version 5.0.0.RELEASEで利用するOSSの一覧を以下に示す。
       - usertype.core
       - 3.2.0.GA
       -
-      - \*1
+      - \*2
     * - 日付操作
       - org.jadira.usertype
       - usertype.spi
       - 3.2.0.GA
       -
-      - \*1
+      - \*2
     * - コネクションプール
       - org.apache.commons
       - commons-dbcp2

--- a/source_en/Overview/FrameworkStack.rst
+++ b/source_en/Overview/FrameworkStack.rst
@@ -476,13 +476,13 @@ List of OSS being used in version 5.0.0.RELEASE.
       - usertype.core
       - 3.2.0.GA
       -
-      - \*1
+      - \*2
     * - Date operation
       - org.jadira.usertype
       - usertype.spi
       - 3.2.0.GA
       -
-      - \*1
+      - \*2
     * - Connection pool
       - org.apache.commons
       - commons-dbcp2


### PR DESCRIPTION
フレームワークスタック一覧中のUserTypeのRemarkが1(MyBatis3使用時に依存)となっていたので2(JPA使用時に依存)に修正。
ご確認をお願いいたします。 #976