### PR TITLE
fix typo about session-management (in English) #940

### DIFF
--- a/source_en/Security/Authentication.rst
+++ b/source_en/Security/Authentication.rst
@@ -891,7 +891,6 @@ specify \ `<sec:concurrency-control> <http://docs.spring.io/spring-security/site
             error-if-maximum-exceeded="true"
             max-sessions="2"
             expired-url="/expiredSessionError.jsp" /><!-- Steps (1) to (3) in the specified order of attribute -->
-        </sec:session-management>
     </sec:session-management>
   </sec:http>
 


### PR DESCRIPTION
session-managementの閉じタグが二つあるタイポの修正。
英語版の修正が漏れていたため、再度pull requestを作成致します。
よろしくお願いいたします。 #940