### PR TITLE
[5.0.x]#940: fix typo session management

### DIFF
--- a/source/Security/Authentication.rst
+++ b/source/Security/Authentication.rst
@@ -888,7 +888,6 @@ Concurrent Session Controlを利用する場合は、
             error-if-maximum-exceeded="true"
             max-sessions="2"
             expired-url="/expiredSessionError.jsp" /><!-- 属性の指定順番で(1)～(3) -->
-        </sec:session-management>
     </sec:session-management>
   </sec:http>
 

--- a/source_en/Security/Authentication.rst
+++ b/source_en/Security/Authentication.rst
@@ -891,7 +891,6 @@ specify \ `<sec:concurrency-control> <http://docs.spring.io/spring-security/site
             error-if-maximum-exceeded="true"
             max-sessions="2"
             expired-url="/expiredSessionError.jsp" /><!-- Steps (1) to (3) in the specified order of attribute -->
-        </sec:session-management>
     </sec:session-management>
   </sec:http>
 


### PR DESCRIPTION
(cherry picked from commit ea87e5d and 3549c00)
Please review #940.