### PR TITLE
[5.0.x] #977: Add explanation about additivity attribute in Logging chapter

### DIFF
--- a/source/ArchitectureInDetail/Logging.rst
+++ b/source/ArchitectureInDetail/Logging.rst
@@ -341,6 +341,12 @@ logback.xml
      - | ロガー名は、com.example.sample以下のロガーが、debugレベル以上のログを出力するように設定する。
    * - | (10)
      - | 監視ログの設定を行う。\ :doc:`ExceptionHandling`\ の\ :ref:`exception-handling-how-to-use-application-configuration-common-label`\ を参照されたい。
+
+       .. warning:: **additivityの設定値について**
+
+           \ ``false``\ を指定すること。\ ``true``\ (デフォルト値)を指定すると、上位のロガー(例えば、root)によって、同じログが出力されてしまう。
+           具体的には、監視ログは3つのアペンダー(\ ``MONITORING_LOG_FILE``\、\ ``STDOUT``\、\ ``APPLICATION_LOG_FILE``\)によって出力される。
+
    * - | (11)
      - | <logger>の指定が無いロガーが、warnレベル以上のログを出力するように設定する。
    * - | (12)

--- a/source_en/ArchitectureInDetail/Logging.rst
+++ b/source_en/ArchitectureInDetail/Logging.rst
@@ -345,7 +345,7 @@ logback.xml
        .. warning:: **About additivity setting value**
 
            Specify \ ``false``\ . If \ ``true``\ (default value) is specified, the same log will be output by upper level logger (for example, root).
-           In the specifically, the monitoring log will be outputted using three appenders(\ ``MONITORING_LOG_FILE``\, \ ``STDOUT``\  and \ ``APPLICATION_LOG_FILE``\).
+           Concretely speaking, the monitoring log will be output using three appenders(\ ``MONITORING_LOG_FILE``\, \ ``STDOUT``\  and \ ``APPLICATION_LOG_FILE``\).
 
    * - | (11)
      - | It is set such that logger without <logger> specification outputs the log of warn level or above.

--- a/source_en/ArchitectureInDetail/Logging.rst
+++ b/source_en/ArchitectureInDetail/Logging.rst
@@ -341,6 +341,12 @@ logback.xml
      - | The logger name is set so that logger under com.example.sample outputs the log above debug level.
    * - | (10)
      - | A monitoring log is set. Refer to \ :ref:`exception-handling-how-to-use-application-configuration-common-label`\  of \ :doc:`ExceptionHandling`\ .
+
+       .. warning:: **About additivity setting value**
+
+           Specify \ ``false``\ . If \ ``true``\ (default value) is specified, the same log will be output by upper level logger (for example, root).
+           In the specifically, the monitoring log will be outputted using three appenders(\ ``MONITORING_LOG_FILE``\, \ ``STDOUT``\  and \ ``APPLICATION_LOG_FILE``\).
+
    * - | (11)
      - | It is set such that logger without <logger> specification outputs the log of warn level or above.
    * - | (12)


### PR DESCRIPTION
I've backported to 5.0.x.
Please review #977 .