### PR TITLE
[5.0.x] #1274: Fixes wrong configuration file name of logback

### DIFF
--- a/source/ArchitectureInDetail/Logging.rst
+++ b/source/ArchitectureInDetail/Logging.rst
@@ -205,7 +205,7 @@ Logbackの設定
      Logbackの設定は、以下のルールによる自動で読み込まれる。
 
      #. クラスパス上のlogback.grovy
-     #. 「1」のファイルが見つからない場合、クラスパス上のlogback-text.xml
+     #. 「1」のファイルが見つからない場合、クラスパス上のlogback-test.xml
      #. 「2」のファイルが見つからない場合、クラスパス上のlogback.xml
      #. 「3」のファイルが見つからない場合、BasicConfiguratorクラスの設定内容(コンソール出力)
 

--- a/source_en/ArchitectureInDetail/Logging.rst
+++ b/source_en/ArchitectureInDetail/Logging.rst
@@ -205,7 +205,7 @@ Settings of Logback
      Settings of Logback are read automatically as per the rules given below.
 
      #. logback.groovy on class path
-     #. If file "1" is not found, logback-text.xml on class path
+     #. If file "1" is not found, logback-test.xml on class path
      #. If file "2" is not found, logback.xml on class path
      #. If file "3" is not found, settings of BasicConfigurator class (console output)
 


### PR DESCRIPTION
(cherry picked from commit f93c1e247bba05823357c73a37e7554b15c8cde0)

Please review #1274 .