### PR TITLE
[5.0.x] #1279: Update links of Java SE JavaDoc to 8

### DIFF
--- a/source/ArchitectureInDetail/MessageManagement.rst
+++ b/source/ArchitectureInDetail/MessageManagement.rst
@@ -815,7 +815,7 @@ Controllerで\ ``ResultMessages``\ を生成して画面に渡し、JSPで\ ``<t
 
             e.ex.an.8001=Cannot upload, Because the file size must be less than {0,number,#}MB.
 
-    詳細は、\ `Javadoc <http://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html>`_\ を参照されたい。
+    詳細は、\ `Javadoc <http://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html>`_\ を参照されたい。
 
 |
 

--- a/source/ImplementationAtEachLayer/ApplicationLayer.rst
+++ b/source/ImplementationAtEachLayer/ApplicationLayer.rst
@@ -2309,7 +2309,7 @@ Spring Frameworkでは、HTML formから送信されたリクエストパラメ�
      - 数値のスタイル（NUMBER,CURRENCY,PERCENT）を指定する。詳細は、`Spring FrameworkのJavadoc <http://docs.spring.io/spring/docs/4.1.7.RELEASE/javadoc-api/org/springframework/format/annotation/NumberFormat.Style.html>`_\ を参照されたい。
    * - 2.
      - pattern
-     - Javaの数値形式を指定する。詳細は、`JAVASEのJavadoc <http://docs.oracle.com/javase/7/docs/api/java/text/DecimalFormat.html>`_\ を参照されたい。
+     - Javaの数値形式を指定する。詳細は、`JAVASEのJavadoc <http://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html>`_\ を参照されたい。
 
 |
 
@@ -2354,7 +2354,7 @@ Spring Frameworkでは、HTML formから送信されたリクエストパラメ�
      - ISOの日時形式を指定する。詳細は、`Spring FrameworkのJavadoc <http://docs.spring.io/spring/docs/4.1.7.RELEASE/javadoc-api/org/springframework/format/annotation/DateTimeFormat.ISO.html>`_\ を参照。
    * - 2.
      - pattern
-     - Javaの日時形式を指定する。詳細は、`JAVASEのJavadoc <http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html>`_\ を参照されたい。
+     - Javaの日時形式を指定する。詳細は、`JAVASEのJavadoc <http://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html>`_\ を参照されたい。
    * - 3.
      - style
      - | 日付と時刻のスタイルを2桁の文字列として指定する。

--- a/source_en/ArchitectureInDetail/MessageManagement.rst
+++ b/source_en/ArchitectureInDetail/MessageManagement.rst
@@ -810,7 +810,7 @@ In such a case, the HTML shown below is output using \ ``<t:messagesPanel />``\ 
 
             e.ex.an.8001=Cannot upload, Because the file size must be less than {0,number,#}MB.
 
-    For details, refer to \ `Javadoc <http://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html>`_\ .
+    For details, refer to \ `Javadoc <http://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html>`_\ .
 
 |
 

--- a/source_en/ImplementationAtEachLayer/ApplicationLayer.rst
+++ b/source_en/ImplementationAtEachLayer/ApplicationLayer.rst
@@ -2306,7 +2306,7 @@ Attributes of ``@NumberFormat`` annotation are given below.
      - Specify number format style (NUMBER, CURRENCY, PERCENT). For details refer to `Javadoc of Spring Framework <http://docs.spring.io/spring/docs/4.1.7.RELEASE/javadoc-api/org/springframework/format/annotation/NumberFormat.Style.html>`_\ .
    * - 2.
      - pattern
-     - Specify number format of Java. Refer to 'Javadoc <http://docs.oracle.com/javase/7/docs/api/java/text/DecimalFormat.html> of JAVASE'_\ for details.
+     - Specify number format of Java. Refer to 'Javadoc <http://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html> of JAVASE'_\ for details.
 
 |
 
@@ -2351,7 +2351,7 @@ Attributes of \ ``@DateTimeFormat``\  annotation are given below.
      - Specify ISO date and time format. For details refer to `Javadoc of Spring Framework <http://docs.spring.io/spring/docs/4.1.7.RELEASE/javadoc-api/org/springframework/format/annotation/DateTimeFormat.ISO.html>`_\ .
    * - 2.
      - pattern
-     - Specify Java date and time format. Refer to 'Javadoc <http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html> of JAVASE'_\ for details.
+     - Specify Java date and time format. Refer to 'Javadoc <http://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html> of JAVASE'_\ for details.
    * - 3.
      - style
      - | Specify style of date and time as two-digit string.


### PR DESCRIPTION
(cherry picked from commit 45809b86b4f8e902a71bfa506cd96fb403ff5d61)

Please review #1279 .