### PR TITLE
Fix typo in Spring Security Tutorial #1374

### DIFF
--- a/source/Security/Tutorial.rst
+++ b/source/Security/Tutorial.rst
@@ -263,7 +263,7 @@ AccountSharedServiceの作成
 
 .. note::
 
-    本ガイドラインでは、Serviceから別のServiceを呼び出し事を推奨していない。
+    本ガイドラインでは、Serviceから別のServiceを呼び出す事を推奨していない。
 
     ドメイン層の処理(Service)を共通化したい場合は、\ ``XxxService``\ という名前ではなく、
     Serviceの処理を共通化するためのServiceであることを示すために、


### PR DESCRIPTION
(cherry picked from commit 1de27e28d760963ae3ebff5736a071b6c6f27ecb)

Please review #1374 .