### PR TITLE
add description of jdk8'class use #1562

### DIFF
--- a/source/Security/Encryption.rst
+++ b/source/Security/Encryption.rst
@@ -270,7 +270,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
 
 - GCMを用いたAESを使用してテキスト（文字列）を暗号化する。
 
-  GCMを用いたAESはSpring Security4.0.2以降で利用可能である。\ :ref:`EncryptionOverviewEncryptionAlgorithmAes`\ で説明したとおり、CBCより処理効率が良い。
+  GCMを用いたAESはSpring Security4.0.2以降、かつ、Java SE8以降で利用可能である。\ :ref:`EncryptionOverviewEncryptionAlgorithmAes`\ で説明したとおり、CBCより処理効率が良い。
 
   .. code-block:: java
 
@@ -484,7 +484,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
             PrivateKey privateKey = keyPair.getPrivate();
 
             byte[] cipherBytes = encryptByPublicKey("Hello World!", publicKey);  // (4)
-            System.out.println(new String(Base64.encode(cipherBytes)));
+            System.out.println(Base64.getEncoder().encodeToString(cipherBytes));
             String plainText = decryptByPrivateKey(cipherBytes, privateKey); // (5)
             System.out.println(plainText);
         } catch (NoSuchAlgorithmException e) {
@@ -510,6 +510,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
 
      * - | (4)
        - | 公開鍵を利用して暗号化処理を行う。処理内容は後述する。
+         | 暗号化された内容を確認したい場合はBase64エンコードする。Java SE8以降の場合は、Java標準のjava.util.Base64を使用する。それ以前の場合は、Spring Securityのorg.springframework.security.crypto.codec.Base64を使用する。
 
      * - | (5)
        - | 秘密鍵を利用して復号処理を行う。処理内容は後述する。

--- a/source/Security/Encryption.rst
+++ b/source/Security/Encryption.rst
@@ -519,7 +519,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
 
   .. note:: **暗号化したデータを文字列として扱いたい場合**
 
-    外部システム連携等、暗号化したデータを文字列でやり取りしたい場合は文字列化の１つの方法としてBase64エンコードをあげられる。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
+    外部システム連携等、暗号化したデータを文字列でやり取りしたい場合は、１つの手段としてBase64エンコードが挙げられる。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
 
     Base64エンコードおよびデコードする方法をJava標準の\ ``java.util.Base64``\ を使用して説明する。
     

--- a/source/Security/Encryption.rst
+++ b/source/Security/Encryption.rst
@@ -270,7 +270,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
 
 - GCMを用いたAESを使用してテキスト（文字列）を暗号化する。
 
-  GCMを用いたAESはSpring Security4.0.2以降、かつ、Java SE8以降で利用可能である。\ :ref:`EncryptionOverviewEncryptionAlgorithmAes`\ で説明したとおり、CBCより処理効率が良い。
+  GCMを用いたAESはSpring Security4.0.2以降で利用可能である。\ :ref:`EncryptionOverviewEncryptionAlgorithmAes`\ で説明したとおり、CBCより処理効率が良い。
 
   .. code-block:: java
 
@@ -293,6 +293,10 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
 
      * - | (2)
        - | 平文を\ ``encrypt``\ メソッドで暗号化する。
+
+  .. note:: **GCMのJava対応**
+
+    GCMを用いたAESはJava SE8以降で使用可能である。詳細については、\ `JDK 8セキュリティの拡張機能 <http://docs.oracle.com/javase/jp/8/docs/technotes/guides/security/enhancements-8.html>`_\を参照されたい。
 
 |
 
@@ -510,7 +514,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
 
      * - | (4)
        - | 公開鍵を利用して暗号化処理を行う。処理内容は後述する。
-         | 暗号化された内容を確認したい場合はBase64エンコードする。Java SE8以降の場合は、Java標準のjava.util.Base64を使用する。それ以前の場合は、Spring Securityのorg.springframework.security.crypto.codec.Base64を使用する。
+         | 暗号化された内容を確認したい場合は\ ``Base64``\ エンコードする。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
 
      * - | (5)
        - | 秘密鍵を利用して復号処理を行う。処理内容は後述する。

--- a/source/Security/Encryption.rst
+++ b/source/Security/Encryption.rst
@@ -294,7 +294,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
      * - | (2)
        - | 平文を\ ``encrypt``\ メソッドで暗号化する。
 
-  .. note:: **GCMのJava対応**
+  .. note:: **GCMを用いたAESへのJavaの対応状況**
 
     GCMを用いたAESはJava SE8以降で使用可能である。詳細については、\ `JDK 8セキュリティの拡張機能 <http://docs.oracle.com/javase/jp/8/docs/technotes/guides/security/enhancements-8.html>`_\を参照されたい。
 
@@ -514,7 +514,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
 
      * - | (4)
        - | 公開鍵を利用して暗号化処理を行う。処理内容は後述する。
-         | 暗号化された内容を確認したい場合は\ ``Base64``\ エンコードする。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
+         | 暗号化された内容を確認したい場合はBase64エンコードする。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
 
      * - | (5)
        - | 秘密鍵を利用して復号処理を行う。処理内容は後述する。

--- a/source/Security/Encryption.rst
+++ b/source/Security/Encryption.rst
@@ -488,7 +488,6 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
             PrivateKey privateKey = keyPair.getPrivate();
 
             byte[] cipherBytes = encryptByPublicKey("Hello World!", publicKey);  // (4)
-            System.out.println(Base64.getEncoder().encodeToString(cipherBytes));
             String plainText = decryptByPrivateKey(cipherBytes, privateKey); // (5)
             System.out.println(plainText);
         } catch (NoSuchAlgorithmException e) {
@@ -514,10 +513,33 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
 
      * - | (4)
        - | 公開鍵を利用して暗号化処理を行う。処理内容は後述する。
-         | 暗号化された内容を確認したい場合はBase64エンコードする。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
 
      * - | (5)
        - | 秘密鍵を利用して復号処理を行う。処理内容は後述する。
+
+  .. note:: **暗号化したデータを文字列として扱いたい場合**
+
+    外部システム連携等、暗号化したデータを文字列でやり取りしたい場合はBASE64エンコードを用いる。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
+
+    BASE64エンコードおよびデコードする方法をJava標準の\ ``java.util.Base64``\ を使用して説明する。
+    
+   * BASE64エンコード
+
+    .. code-block:: java
+
+            // omitted
+            byte[] cipherBytes = encryptByPublicKey("Hello World!", publicKey);  // 暗号化処理
+            String cipherString = Base64.getEncoder().encodeToString(cipherBytes);  // バイト配列の暗号文を文字列に変換
+            // omitted
+
+   * BASE64デコード
+
+    .. code-block:: java
+
+            // omitted
+            byte[] cipherBytes = Base64.getDecoder().decode(cipherString); // 文字列の暗号文をバイト配列に変換
+            String plainText = decryptByPrivateKey(cipherBytes, privateKey); // 復号処理
+            // omitted
 
 |
 

--- a/source/Security/Encryption.rst
+++ b/source/Security/Encryption.rst
@@ -519,7 +519,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
 
   .. note:: **暗号化したデータを文字列として扱いたい場合**
 
-    外部システム連携等、暗号化したデータを文字列でやり取りしたい場合はBase64エンコードを用いる。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
+    外部システム連携等、暗号化したデータを文字列でやり取りしたい場合は文字列化の１つの方法としてBase64エンコードをあげられる。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
 
     Base64エンコードおよびデコードする方法をJava標準の\ ``java.util.Base64``\ を使用して説明する。
     

--- a/source/Security/Encryption.rst
+++ b/source/Security/Encryption.rst
@@ -484,7 +484,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
             PrivateKey privateKey = keyPair.getPrivate();
 
             byte[] cipherBytes = encryptByPublicKey("Hello World!", publicKey);  // (4)
-            System.out.println(Base64.getEncoder().encodeToString(cipherBytes));
+            System.out.println(new String(Base64.encode(cipherBytes)));
             String plainText = decryptByPrivateKey(cipherBytes, privateKey); // (5)
             System.out.println(plainText);
         } catch (NoSuchAlgorithmException e) {

--- a/source/Security/Encryption.rst
+++ b/source/Security/Encryption.rst
@@ -519,7 +519,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
 
   .. note:: **暗号化したデータを文字列として扱いたい場合**
 
-    外部システム連携等、暗号化したデータを文字列でやり取りしたい場合は、１つの手段としてBase64エンコードが挙げられる。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
+    外部システム連携等、暗号化したデータを文字列でやり取りしたい場合は、1つの手段としてBase64エンコードが挙げられる。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
 
     Base64エンコードおよびデコードする方法をJava標準の\ ``java.util.Base64``\ を使用して説明する。
     

--- a/source/Security/Encryption.rst
+++ b/source/Security/Encryption.rst
@@ -519,11 +519,11 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
 
   .. note:: **暗号化したデータを文字列として扱いたい場合**
 
-    外部システム連携等、暗号化したデータを文字列でやり取りしたい場合はBASE64エンコードを用いる。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
+    外部システム連携等、暗号化したデータを文字列でやり取りしたい場合はBase64エンコードを用いる。Java SE8以降の場合は、Java標準の\ ``java.util.Base64``\ を使用する。それ以前の場合は、Spring Securityの\ ``org.springframework.security.crypto.codec.Base64``\ を使用する。
 
-    BASE64エンコードおよびデコードする方法をJava標準の\ ``java.util.Base64``\ を使用して説明する。
+    Base64エンコードおよびデコードする方法をJava標準の\ ``java.util.Base64``\ を使用して説明する。
     
-   * BASE64エンコード
+   * Base64エンコード
 
     .. code-block:: java
 
@@ -532,7 +532,7 @@ Oracleなど、一部のJava製品ではAESの鍵長256ビットを扱うため�
             String cipherString = Base64.getEncoder().encodeToString(cipherBytes);  // バイト配列の暗号文を文字列に変換
             // omitted
 
-   * BASE64デコード
+   * Base64デコード
 
     .. code-block:: java
 


### PR DESCRIPTION
@ikeyat , please review. #1562

I fixed two places.
One is in section 6.8.2.1.1, add description of gcm can be used in later jdk8.
And the other one is in section 6.8.2.2.1, add description of Base64.