### PR TITLE
Modified index of PDF for 5.1.0.RELEASE guideline. #1680

### DIFF
--- a/source/ArchitectureInDetail/REST.rst
+++ b/source/ArchitectureInDetail/REST.rst
@@ -4957,7 +4957,7 @@ How to extend
 
   * :file:`org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdvice`
 
-   .. tabularcolumns:: |p{0.10\linewidth}|p{0.90\linewidth}|
+   .. tabularcolumns:: |p{0.10\linewidth}|p{0.20\linewidth}|p{0.70\linewidth}|
    .. list-table::
       :header-rows: 1
       :widths: 10 20 70
@@ -4987,7 +4987,7 @@ How to extend
 
   * :file:`org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice`
 
-   .. tabularcolumns:: |p{0.10\linewidth}|p{0.90\linewidth}|
+   .. tabularcolumns:: |p{0.10\linewidth}|p{0.20\linewidth}|p{0.70\linewidth}|
    .. list-table::
       :header-rows: 1
       :widths: 10 20 70


### PR DESCRIPTION
@ikeyat さん、5.1.0.RELEASEガイドラインPDFにおける目次内容の表示不具合に対応しました。 #1680
カラム数が誤っていた個所を修正したところ、目次が表示されるようになりました。
ご確認よろしくお願いします。