### PR TITLE
modify warning on sphinx build backport to 1.0.x #1879

### DIFF
--- a/source/Appendix/SpringComprehensionCheck.rst
+++ b/source/Appendix/SpringComprehensionCheck.rst
@@ -71,7 +71,7 @@ Spring Framework理解度チェックテスト
 #. \ ``com.example.domain``\ パッケージ以下がcomponent scanの対象となるように以下のBean定義の(1)～(3)を埋めてください。
 
 
-    .. code-block:: xml
+    .. code-block:: text
     
         <context:(1) (2)="(3)" />
         
@@ -102,9 +102,9 @@ Spring Framework理解度チェックテスト
         @Service
         @Transactional
         public class XxxServiceImpl implements XxxService {
-          @(2)("${emails.min.count}")
+          @xxx("${emails.min.count}") // (2)xxx部分
           protected int emailsMinCount;
-          @(2)("${emails.max.count}")
+          @xxx("${emails.max.count}") // (2)xxx部分
           protected int emailsMaxCount;
           // omitted
         }
@@ -127,7 +127,7 @@ Spring Framework理解度チェックテスト
 
 #. \ ``@Transactional``\ アノテーションによるトランザクション管理を行うために以下のBean定義の(*)を埋めてください。
 
-    .. code-block:: xml
+    .. code-block:: text
 
         <tx:(*) />
 

--- a/source/ArchitectureInDetail/MessageManagement.rst
+++ b/source/ArchitectureInDetail/MessageManagement.rst
@@ -618,7 +618,7 @@ How to use
 
         国際化に対応する場合は、
 
-        .. code-block:: properties
+        .. code-block:: text
 
             src/main/resources/i18n
                                 ├ application-messages.properties (英語メッセージ)

--- a/source_en/Appendix/SpringComprehensionCheck.rst
+++ b/source_en/Appendix/SpringComprehensionCheck.rst
@@ -71,7 +71,7 @@ Spring Framework Comprehension Check
 #. Fill (1)-(3) of the following Bean definition such that contents in \ ``com.example.domain``\  package becomes target of component scan.
 
 
-    .. code-block:: xml
+    .. code-block:: text
     
         <context:(1) (2)="(3)" />
         
@@ -102,9 +102,9 @@ Spring Framework Comprehension Check
         @Service
         @Transactional
         public class XxxServiceImpl implements XxxService {
-          @(2)("${emails.min.count}")
+          @xxx("${emails.min.count}") // (2)
           protected int emailsMinCount;
-          @(2)("${emails.max.count}")
+          @xxx("${emails.max.count}") // (2)
           protected int emailsMaxCount;
           // omitted
         }
@@ -127,7 +127,7 @@ Spring Framework Comprehension Check
 
 #. Insert (*) of following Bean definition for performing transaction management using  \ ``@Transactional``\  annotation.
 
-    .. code-block:: xml
+    .. code-block:: text
 
         <tx:(*) />
 

--- a/source_en/ArchitectureInDetail/MessageManagement.rst
+++ b/source_en/ArchitectureInDetail/MessageManagement.rst
@@ -613,7 +613,7 @@ Display of messages set in properties
 
         When supporting internationalization,
 
-        .. code-block:: properties
+        .. code-block:: text
 
             src/main/resources/i18n
                                 ├ application-messages.properties (English message)


### PR DESCRIPTION
Please review #1879 
 backport to 1.0.x
 without email.rst & CSRF.rst 

Email.rst doesn't exist in this version.
 The error doesn't exist in CSRF.rst of this version.
 so, I modifyed the others.
