### PR TITLE
5.1.x_backport_Fix_Description_of_paramName_in_LocaleChangeInterceptor.#1354

### DIFF
--- a/source/ArchitectureInDetail/Internationalization.rst
+++ b/source/ArchitectureInDetail/Internationalization.rst
@@ -288,6 +288,7 @@ LocaleChangeInterceptorの設定
       <mvc:exclude-mapping path="/**/*.html" />
       <bean
         class="org.springframework.web.servlet.i18n.LocaleChangeInterceptor">  <!-- (1) -->
+        <property name="paramName" value="lang"/>  <!-- (2) --> 
       </bean>
       <!-- omitted -->
     </mvc:interceptor>
@@ -302,28 +303,9 @@ LocaleChangeInterceptorの設定
       - | 説明
     * - | (1)
       - | Spring MVCのインタセプターに、 ``org.springframework.web.servlet.i18n.LocaleChangeInterceptor`` を定義する。
-
-.. note::
-
-    **Localeを指定するリクエストパラメータ名の変更方法**
-
-     .. code-block:: xml
-
-        <bean
-            class="org.springframework.web.servlet.i18n.LocaleChangeInterceptor">
-            <property name="paramName" value="lang"/>  <!-- (2) -->
-        </bean>
-
-     .. tabularcolumns:: |p{0.10\linewidth}|p{0.90\linewidth}|
-     .. list-table::
-        :header-rows: 1
-        :widths: 10 90
-
-        * - | 項番
-          - | 説明
-        * - | (2)
-          - | \ ``paramName``\ プロパティにリクエストパラメータ名を指定する。上記例では、"リクエストURL?lang=xx"となる。
-            | **paramNameプロパティを省略した場合、"locale"が設定される。** "リクエストURL?locale=xx"で :ref:`使用可能<i18n_set_locale_jsp>` となる。
+    * - | (2)  
+      - | \ ``paramName``\ プロパティにリクエストパラメータ名を指定する。上記例では、"リクエストURL?lang=xx"となる。  
+        | **paramNameプロパティを省略した場合、"locale"が設定される。** "リクエストURL?locale=xx"で :ref:`使用可能<i18n_set_locale_jsp>` となる。  
 
 |
 

--- a/source/ArchitectureInDetail/Internationalization.rst
+++ b/source/ArchitectureInDetail/Internationalization.rst
@@ -302,7 +302,7 @@ LocaleChangeInterceptorの設定
       - | 説明
     * - | (1)
       - | Spring MVCのインタセプターに、 ``org.springframework.web.servlet.i18n.LocaleChangeInterceptor`` を定義する。
-        | 本例ではparamNameプロパティを省略しているため、リクエストパラメータ名にはデフォルト値である"locale"が設定される。この設定により、"リクエストURL?locale=xx"で :ref:`使用可能<i18n_set_locale_jsp>` となる。
+        | この設定により、"リクエストURL?locale=xx"で :ref:`使用可能<i18n_set_locale_jsp>` となる。
 
 .. note::
 

--- a/source/ArchitectureInDetail/Internationalization.rst
+++ b/source/ArchitectureInDetail/Internationalization.rst
@@ -288,7 +288,6 @@ LocaleChangeInterceptorの設定
       <mvc:exclude-mapping path="/**/*.html" />
       <bean
         class="org.springframework.web.servlet.i18n.LocaleChangeInterceptor">  <!-- (1) -->
-        <property name="paramName" value="lang"/>  <!-- (2) --> 
       </bean>
       <!-- omitted -->
     </mvc:interceptor>
@@ -303,9 +302,28 @@ LocaleChangeInterceptorの設定
       - | 説明
     * - | (1)
       - | Spring MVCのインタセプターに、 ``org.springframework.web.servlet.i18n.LocaleChangeInterceptor`` を定義する。
-    * - | (2)  
-      - | \ ``paramName``\ プロパティにリクエストパラメータ名を指定する。上記例では、"リクエストURL?lang=xx"となる。  
-        | **paramNameプロパティを省略した場合、"locale"が設定される。** "リクエストURL?locale=xx"で :ref:`使用可能<i18n_set_locale_jsp>` となる。  
+        | 本例ではparamNameプロパティを省略しているため、リクエストパラメータ名にはデフォルト値である"locale"が設定される。この設定により、"リクエストURL?locale=xx"で :ref:`使用可能<i18n_set_locale_jsp>` となる。
+
+.. note::
+
+    **Localeを指定するリクエストパラメータ名の変更方法**
+
+     .. code-block:: xml
+
+        <bean
+            class="org.springframework.web.servlet.i18n.LocaleChangeInterceptor">
+            <property name="paramName" value="lang"/>  <!-- (2) -->
+        </bean>
+
+     .. tabularcolumns:: |p{0.10\linewidth}|p{0.90\linewidth}|
+     .. list-table::
+        :header-rows: 1
+        :widths: 10 90
+
+        * - | 項番
+          - | 説明
+        * - | (2)
+          - | \ ``paramName``\ プロパティにリクエストパラメータ名を指定する。上記例では、"リクエストURL?lang=xx"となる。
 
 |
 


### PR DESCRIPTION
Please review #1354 .
 (backport to 5.1.x)
 I counldn't cherry-pick automatically. I backported manually.

I reproduced commit  91d1f034a2826d5e42cc6165b983cab76bd0fd1c  /   9990e6d7f3c029825571a7151ea2e2b59eb9460a  /  91a08a4faa65a75c31b0ac2ff42328232b62ce2c
