### PR TITLE
「4.1.2.3.1. Spring Validatorによる相関項目チェック実装」の誤記 #2397

### DIFF
--- a/source/ArchitectureInDetail/WebApplicationDetail/Validation.rst
+++ b/source/ArchitectureInDetail/WebApplicationDetail/Validation.rst
@@ -1807,7 +1807,7 @@ Spring Validatorによる相関項目チェック実装
      - | 特になし
      - | 確認用パスワード
 
-「confirmPasswordと同じ値であること」というルールは\ ``password``\ フィールドと\ ``passwordConfirm``\ フィールドの両方の情報が必要であるため、相関項目チェックルールである。
+「confirmPasswordと同じ値であること」というルールは\ ``password``\ フィールドと\ ``confirmPassword``\ フィールドの両方の情報が必要であるため、相関項目チェックルールである。
 
 * フォームクラス
 


### PR DESCRIPTION
(cherry picked from commit 8bd062b4379071537f16701ebb870711e6bb2b12)

Please review #2397 . Backport for 5.2.x .
