### PR TITLE
fix typo in sample of spring-mvc.xml. #2410

### DIFF
--- a/source/Overview/FirstApplication.rst
+++ b/source/Overview/FirstApplication.rst
@@ -151,7 +151,7 @@ Spring MVCの設定方法を理解するために、生成されたSpring MVCの
                 <bean
                     class="org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver" />
             </mvc:argument-resolvers>
-            <!-- workarround to CVE-2016-5007. -->
+            <!-- workaround to CVE-2016-5007. -->
             <mvc:path-matching path-matcher="pathMatcher" />
         </mvc:annotation-driven>
 

--- a/source/Tutorial/TutorialREST.rst
+++ b/source/Tutorial/TutorialREST.rst
@@ -562,7 +562,7 @@ spring-mvc-rest.xmlの作成
                 <bean
                     class="org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver" />
             </mvc:argument-resolvers>
-            <!-- workarround to CVE-2016-5007. -->
+            <!-- workaround to CVE-2016-5007. -->
             <mvc:path-matching path-matcher="pathMatcher" />
             <mvc:message-converters register-defaults="false">
                 <!-- (1) -->

--- a/source/Tutorial/TutorialSecurity.rst
+++ b/source/Tutorial/TutorialSecurity.rst
@@ -1267,7 +1267,7 @@ Spring Securityと関係のない設定については、説明を割愛する�
                 <bean
                     class="org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver" />
             </mvc:argument-resolvers>
-            <!-- workarround to CVE-2016-5007. -->
+            <!-- workaround to CVE-2016-5007. -->
             <mvc:path-matching path-matcher="pathMatcher" />
         </mvc:annotation-driven>
 

--- a/source/Tutorial/TutorialTodo.rst
+++ b/source/Tutorial/TutorialTodo.rst
@@ -4058,7 +4058,7 @@ spring-mvc.xml
                 <bean
                     class="org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver" />
             </mvc:argument-resolvers>
-            <!-- workarround to CVE-2016-5007. -->
+            <!-- workaround to CVE-2016-5007. -->
             <mvc:path-matching path-matcher="pathMatcher" />
         </mvc:annotation-driven>
 

--- a/source_en/Overview/FirstApplication.rst
+++ b/source_en/Overview/FirstApplication.rst
@@ -149,7 +149,7 @@ To understand the configuration of Spring MVC, the generated Spring MVC configur
                 <bean
                     class="org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver" />
             </mvc:argument-resolvers>
-            <!-- workarround to CVE-2016-5007. -->
+            <!-- workaround to CVE-2016-5007. -->
             <mvc:path-matching path-matcher="pathMatcher" />
         </mvc:annotation-driven>
 

--- a/source_en/Tutorial/TutorialREST.rst
+++ b/source_en/Tutorial/TutorialREST.rst
@@ -563,7 +563,7 @@ Creation of spring-mvc-rest.xml
                 <bean
                     class="org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver" />
             </mvc:argument-resolvers>
-            <!-- workarround to CVE-2016-5007. -->
+            <!-- workaround to CVE-2016-5007. -->
             <mvc:path-matching path-matcher="pathMatcher" />
             <mvc:message-converters register-defaults="false">
                 <!-- (1) -->

--- a/source_en/Tutorial/TutorialSecurity.rst
+++ b/source_en/Tutorial/TutorialSecurity.rst
@@ -1268,7 +1268,7 @@ Description of settings not related to Spring Security is omitted.
                 <bean
                     class="org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver" />
             </mvc:argument-resolvers>
-            <!-- workarround to CVE-2016-5007. -->
+            <!-- workaround to CVE-2016-5007. -->
             <mvc:path-matching path-matcher="pathMatcher" />
         </mvc:annotation-driven>
 

--- a/source_en/Tutorial/TutorialTodo.rst
+++ b/source_en/Tutorial/TutorialTodo.rst
@@ -4053,7 +4053,7 @@ The Spring MVC related definitions are done in \ :file:`spring-mvc.xml`\.
                 <bean
                     class="org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver" />
             </mvc:argument-resolvers>
-            <!-- workarround to CVE-2016-5007. -->
+            <!-- workaround to CVE-2016-5007. -->
             <mvc:path-matching path-matcher="pathMatcher" />
         </mvc:annotation-driven>
 


### PR DESCRIPTION
(cherry picked from commit de3e68a5319c0340e408e2b2db6c09d47b37c9e2)

Please review #2410 .
