### PR TITLE
[5.2.x]remove highlighting in spring-security.xml for authorization.#2399

### DIFF
--- a/source/Security/Authorization.rst
+++ b/source/Security/Authorization.rst
@@ -376,7 +376,6 @@ Spring Securityは定義した順番でリクエストとのマッチング処�
     下記の設定例は、\ ``/restrict``\に対して「ROLE_ADMIN」ロールを持つユーザからのアクセスのみを許可している。
 
       .. code-block:: xml
-         :emphasize-lines: 2,3
 
           <sec:http>
               <sec:intercept-url pattern="/restrict.*" access="hasRole('ADMIN')" /> <!-- (1) --> 


### PR DESCRIPTION
Please review #2399 .
 :emphasize-lines: 2,3 の除去5.2.x対応版です。