### PR TITLE
「4.1.2.3.1. Spring Validatorによる相関項目チェック実装」の誤記  #2397 

### DIFF
--- a/source_en/ArchitectureInDetail/WebApplicationDetail/Validation.rst
+++ b/source_en/ArchitectureInDetail/WebApplicationDetail/Validation.rst
@@ -1798,7 +1798,7 @@ Correlation item check implementation using Spring Validator
      - | Nothing in particular
      - | Confirm password
 
-Check rule "Must be same as confirmPassword" is validation of correlated items as \ ``password``\  field and \ ``passwordConfirm``\  field should have the same value.
+Check rule "Must be same as confirmPassword" is validation of correlated items as \ ``password``\  field and \ ``confirmPassword``\  field should have the same value.
 
 * Form class
 


### PR DESCRIPTION
(cherry picked from commit e92ff039ecf7bcc69f669991f52a75a821b6456d)

Please review #2397 
fix for english version