### PR TITLE
[5.2.x] Typo in JMS section.  #2153

### DIFF
--- a/source_en/ArchitectureInDetail/MessagingDetail/JMS.rst
+++ b/source_en/ArchitectureInDetail/MessagingDetail/JMS.rst
@@ -1429,7 +1429,7 @@ Respective descriptions are as below.
          - Implementation details
        * - | Producer side
          - | Specify Destination in header attribute \ ``JMSReplyTo``\  of messages in accordance with JMS standards.
-           | For editing of header attribute, refer \ :ref`JMSHowToUseSettingForSendWithHeader`\.
+           | For editing of header attribute, refer \ :ref:`JMSHowToUseSettingForSendWithHeader`\.
        * - | Consumer side
          - | Return objects which send a message.
 


### PR DESCRIPTION
(cherry picked from commit 4a125a633c2027d05cc3139aa91804f0d57447bd)

Please review #2153 .
Fix for english version.
backport for 5.2.x
