### PR TITLE
fix double copyright #2628

### DIFF
--- a/conf/html/conf.py
+++ b/conf/html/conf.py
@@ -41,7 +41,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'TERASOLUNA Server Framework for Java (5.x) Development Guideline'
-copyright = u'2013-2017, NTT DATA Corporation'
+copyright = u'© Copyright 2013-2017, NTT DATA Corporation. © Copyright 2017, NTT Corporation.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/conf/html_for_githubpages/conf.py
+++ b/conf/html_for_githubpages/conf.py
@@ -41,7 +41,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'TERASOLUNA Server Framework for Java (5.x) Development Guideline'
-copyright = u'2013-2017, NTT DATA Corporation'
+copyright = u'© Copyright 2013-2017, NTT DATA Corporation. © Copyright 2017, NTT Corporation.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/conf/latexpdfen/conf.py
+++ b/conf/latexpdfen/conf.py
@@ -41,7 +41,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'TERASOLUNA Server Framework for Java (5.x) Development Guideline'
-copyright = u'2013-2017, NTT DATA Corporation'
+copyright = u'© Copyright 2013-2017, NTT DATA Corporation. © Copyright 2017, NTT Corporation.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/conf/latexpdfja/conf.py
+++ b/conf/latexpdfja/conf.py
@@ -41,7 +41,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'TERASOLUNA Server Framework for Java (5.x) Development Guideline'
-copyright = u'2013-2017, NTT DATA Corporation'
+copyright = u'© Copyright 2013-2017, NTT DATA Corporation. © Copyright 2017, NTT Corporation.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/theme/solar/layout.html
+++ b/theme/solar/layout.html
@@ -27,7 +27,7 @@
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
     {%- endif %}
     {%- if show_sphinx %}
-    {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> {{ sphinx_version }}.Theme by <a href="http://github.com/vkvn">vkvn</a>{% endtrans %}
+      {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> {{ sphinx_version }}.Theme by <a href="http://github.com/vkvn">vkvn</a>{% endtrans %}
     {%- endif %}
     </div>
     

--- a/theme/solar/layout.html
+++ b/theme/solar/layout.html
@@ -21,11 +21,7 @@
 {%- block footer %}
     <div class="footer">
     {%- if show_copyright %}
-      {%- if hasdoc('copyright') %}
-        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
-      {%- else %}
-        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}
-      {%- endif %}
+      {% trans copyright=copyright|e %}{{ copyright }}{% endtrans %}
     {%- endif %}
     {%- if last_updated %}
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}

--- a/theme/solar_for_githubpages/layout.html
+++ b/theme/solar_for_githubpages/layout.html
@@ -27,7 +27,7 @@
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
     {%- endif %}
     {%- if show_sphinx %}
-    {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> {{ sphinx_version }}.Theme by <a href="http://github.com/vkvn">vkvn</a>{% endtrans %}
+      {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> {{ sphinx_version }}.Theme by <a href="http://github.com/vkvn">vkvn</a>{% endtrans %}
     {%- endif %}
     </div>
     

--- a/theme/solar_for_githubpages/layout.html
+++ b/theme/solar_for_githubpages/layout.html
@@ -21,11 +21,7 @@
 {%- block footer %}
     <div class="footer">
     {%- if show_copyright %}
-      {%- if hasdoc('copyright') %}
-        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
-      {%- else %}
-        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}
-      {%- endif %}
+      {% trans copyright=copyright|e %}{{ copyright }}{% endtrans %}
     {%- endif %}
     {%- if last_updated %}
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}


### PR DESCRIPTION
Please review #2628 .

本Issue対応に当たり、copyrightを２つ貼ることになった。
当初はSphinxの設定ファイル、conf.pyにおいてcopyrightを持つ変数を２つ持つことで対応しようとしたが、変数名をcopyrightから変更した場合（ex. copyright1）、layout.htmlで認識されないことが判明した。
そのため、２つのcopyrightを一つのconf.pyにあるcopyright変数に入れるために、表示される© Copyrightの部分もまとめてconf.pyのcopyright変数に入れることにした。
しかし、Layout.htmlは元々Sphinxのデフォルトのファイルを流用している。
そのため、© Copyrightの部分は、layout.htmlによって動的にリンクが貼られるようになっている。
しかし、conf.pyのcopyright変数には動的にリンクを貼ることは出来ない。
このため、guidelineの© Copyright部分にはリンクが貼られることはないことを確認した上で、今回の対応で、hasdoc()を使用してリンクを貼っている場所を削除した。