### PR TITLE
[5.3.x] Delete ControllerAdvice annotation attribute. #2281

### DIFF
--- a/source/Tutorial/TutorialREST.rst
+++ b/source/Tutorial/TutorialREST.rst
@@ -1809,7 +1809,7 @@ DELETE Todoの実装
 REST APIのエラーハンドリングを行うクラスの作成
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  
 
-| REST APIのエラーハンドリングは、Spring MVCから提供されている\ ``org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler``\ を継承したクラスを作成し、\ ``@ControllerAdvice``\アノテーションを付与する方法でハンドリングし、REST APIに関わる処理に限定するために ``(annotations = RestController.class)`` の属性を付与する事を推奨する。
+| REST APIのエラーハンドリングは、Spring MVCから提供されている\ ``org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler``\ を継承したクラスを作成し、\ ``@ControllerAdvice``\アノテーションを付与する方法でハンドリングする。
 | 以下に、\ ``ResponseEntityExceptionHandler``\を継承した\ ``todo.api.common.error.RestGlobalExceptionHandler``\ クラスを作成する。
 
 .. figure:: ./images_rest/exception-handlingclass.png


### PR DESCRIPTION
(cherry picked from commit 8ec70143c972a03f1853e4c6be74f01c04e1a5d1)

Please review #2281. Backport for 5.3.x.
