### PR TITLE
[5.3.x] typo of caret at maven command. #2762

### DIFF
--- a/source/ImplementationAtEachLayer/CreateProject.rst
+++ b/source/ImplementationAtEachLayer/CreateProject.rst
@@ -446,11 +446,11 @@ Webサービスを提供するAPサーバにアプリケーションをリリー
 
  .. code-block:: bash
 
-  mvn org.apache.maven.plugins:maven-dependency-plugin:2.5:get \
-   -DgroupId=com.example \
-   -DartifactId=mywebapp \
-   -Dversion=0.0.1-SNAPSHOT \
-   -Dpackaging=war \
+  mvn org.apache.maven.plugins:maven-dependency-plugin:2.5:get^
+   -DgroupId=com.example^
+   -DartifactId=mywebapp^
+   -Dversion=0.0.1-SNAPSHOT^
+   -Dpackaging=war^
    -Ddest=${WORKSPACE}/target/mywebapp.war
 
  これで、targetというディレクトリ配下にmywebapp.warファイルがダウンロードされる。

--- a/source_en/ImplementationAtEachLayer/CreateProject.rst
+++ b/source_en/ImplementationAtEachLayer/CreateProject.rst
@@ -446,11 +446,11 @@ This has same flow irrespective of snapshot release or official release.
 
  .. code-block:: bash
 
-  mvn org.apache.maven.plugins:maven-dependency-plugin:2.5:get \
-   -DgroupId=com.example \
-   -DartifactId=mywebapp \
-   -Dversion=0.0.1-SNAPSHOT \
-   -Dpackaging=war \
+  mvn org.apache.maven.plugins:maven-dependency-plugin:2.5:get^
+   -DgroupId=com.example^
+   -DartifactId=mywebapp^
+   -Dversion=0.0.1-SNAPSHOT^
+   -Dpackaging=war^
    -Ddest=${WORKSPACE}/target/mywebapp.war
 
  With this, mywebapp.war file is downloaded under the target directory.


### PR DESCRIPTION
(cherry picked from commit c68663961e7814854d3ddc75efc8d8c6bbad4281)

Please review #2762. Backport for 5.3.x
