### PR TITLE
[5.1.x] Add note for risk that plaintext passwords are described log. #2092

### DIFF
--- a/source/Introduction/ChangeLog.rst
+++ b/source/Introduction/ChangeLog.rst
@@ -49,6 +49,12 @@
 
         * \ ``<definition>`` \タグ(Tiles定義ファイル)の\ ``name`` \属性のマッチングに関する説明、及び関連する箇所の誤解を招く表現を修正(\ `guideline#2717 <https://github.com/terasolunaorg/guideline/issues/2717>`_\ )
 
+    * -
+      - :doc:`../Security/Authentication`
+      - 記載内容の追加
+
+        * パスワードを\ ``StandardPasswordEncoder`` \によるハッシュ化によって管理する場合の注意事項を追加(\ `guideline#2092 <https://github.com/terasolunaorg/guideline/issues/2092>`_\ )
+
     * -  
       - :doc:`../Security/Authorization`  
       - 記載内容の追加  

--- a/source/Security/Authentication.rst
+++ b/source/Security/Authentication.rst
@@ -879,6 +879,12 @@ Spring Securityは、\ ``PasswordEncoder``\ インタフェースの実装クラ
       - | ハッシュ化しない実装クラス。
         | テスト用のクラスなであり、実際のアプリケーションで使用することはない。
 
+.. note::
+  パスワードをStandardPasswordEncoderによるハッシュ化によって管理する場合、すべてのパスワードがハッシュ化されている必要がある。
+  ハッシュ化されていない平文パスワードのアカウントで認証しようとした場合、例外メッセージに以下のような形でパスワードが出力されてしまうため注意が必要である。
+  
+  java.lang.IllegalArgumentException: Non-hex character in input: (DB等で管理されている「平文パスワード」)
+
 本節では、Spring Securityが利用を推奨している\ ``BCryptPasswordEncoder``\ の使い方について説明する。
 
 |

--- a/source/Security/Authentication.rst
+++ b/source/Security/Authentication.rst
@@ -880,10 +880,11 @@ Spring Securityは、\ ``PasswordEncoder``\ インタフェースの実装クラ
         | テスト用のクラスなであり、実際のアプリケーションで使用することはない。
 
 .. note::
-  パスワードをStandardPasswordEncoderによるハッシュ化によって管理する場合、すべてのパスワードがハッシュ化されている必要がある。
-  ハッシュ化されていない平文パスワードのアカウントで認証しようとした場合、例外メッセージに以下のような形でパスワードが出力されてしまうため注意が必要である。
-  
-  java.lang.IllegalArgumentException: Non-hex character in input: (DB等で管理されている「平文パスワード」)
+
+    パスワードを\ ``StandardPasswordEncoder`` \によるハッシュ化によって管理する場合、すべてのパスワードがハッシュ化されている必要がある。
+    パスワードが平文で保存されているアカウントが存在し、そのアカウントで認証しようとした場合、例外メッセージに以下のような形でパスワードが出力されてしまうため注意が必要である。
+
+    \ ``java.lang.IllegalArgumentException: Non-hex character in input: (DB等で管理されている「平文パスワード」)`` \
 
 本節では、Spring Securityが利用を推奨している\ ``BCryptPasswordEncoder``\ の使い方について説明する。
 


### PR DESCRIPTION
Please review #2092. Backport for 5.1.2.
