### PR TITLE
[5.0.x] Add note for risk that plaintext passwords are described log. #2092

### DIFF
--- a/source/Introduction/ChangeLog.rst
+++ b/source/Introduction/ChangeLog.rst
@@ -49,6 +49,12 @@
 
         * \ ``<definition>`` \タグ(Tiles定義ファイル)の\ ``name`` \属性のマッチングに関する説明、及び関連する箇所の誤解を招く表現を修正(\ `guideline#2717 <https://github.com/terasolunaorg/guideline/issues/2717>`_\ )
 
+    * -
+      - :doc:`../Security/PasswordHashing`
+      - 記載内容の追加
+
+        * パスワードを\ ``StandardPasswordEncoder`` \によるハッシュ化によって管理する場合の注意事項を追加(\ `guideline#2092 <https://github.com/terasolunaorg/guideline/issues/2092>`_\ )
+
     * -  
       - :doc:`../Security/Authorization`  
       - 記載内容の追加

--- a/source/Security/PasswordHashing.rst
+++ b/source/Security/PasswordHashing.rst
@@ -251,7 +251,12 @@ StandardPasswordEncoderの設定例
          * - | (1)
            - | 環境変数:PASSWORD_ENCODER_SECRETから値を取得する。
 
+  .. note::
 
+      パスワードを\ ``StandardPasswordEncoder`` \によるハッシュ化によって管理する場合、すべてのパスワードがハッシュ化されている必要がある。
+      パスワードが平文で保存されているアカウントが存在し、そのアカウントで認証しようとした場合、例外メッセージに以下のような形でパスワードが出力されてしまうため注意が必要である。
+
+      \ ``java.lang.IllegalArgumentException: Non-hex character in input: (DB等で管理されている「平文パスワード」)`` \
 
   | Javaクラス例は\ ``BCryptPasswordEncoder``\ と同様のため、\ :ref:`BCryptPasswordEncoder`\ を参照されたい。
 


### PR DESCRIPTION
Please review #2092. Backport for 5.0.3.
