### PR TITLE
[1.0.x] Add note for risk that plaintext passwords are described log. #2092

### DIFF
--- a/source/Introduction/ChangeLog.rst
+++ b/source/Introduction/ChangeLog.rst
@@ -10,6 +10,28 @@
       - 更新箇所
       - 更新内容
 
+    * - xxx-xx-xx
+      - \-
+      - 1.0.7 RELEASE版公開
+
+        * 更新内容の詳細は、\ `1.0.7のIssue一覧 <https://github.com/terasolunaorg/guideline/issues?utf8=%E2%9C%93&q=label%3A1.0.7%20is%3Aissue%20is%3Aclosed%20>`_\ を参照されたい。
+
+    * -
+      - 全般
+      - ガイドラインの誤記(タイプミスや単純な記述ミスなど)の修正
+
+        * 修正内容の詳細は、\ `1.0.7のIssue一覧(clerical error) <https://github.com/terasolunaorg/guideline/issues?utf8=%E2%9C%93&q=%20label%3A1.0.7%20is%3Aclosed%20label%3A%22clerical%20error%22%20>`_\ を参照されたい。
+
+        記載内容の改善
+
+        * 改善内容の詳細は、\ `1.0.7のIssue一覧(improvement) <https://github.com/terasolunaorg/guideline/issues?utf8=%E2%9C%93&q=label%3A1.0.7%20label%3Aimprovement%20is%3Aclosed%20>`_\ を参照されたい。
+
+    * -
+      - :doc:`../Security/PasswordHashing`
+      - 記載内容の追加
+
+        * パスワードを\ ``StandardPasswordEncoder`` \によるハッシュ化によって管理する場合の注意事項を追加(\ `guideline#2092 <https://github.com/terasolunaorg/guideline/issues/2092>`_\ )
+
     * - 2017-03-17
       - \-
       - 1.0.6 RELEASE版公開

--- a/source/Security/PasswordHashing.rst
+++ b/source/Security/PasswordHashing.rst
@@ -250,7 +250,12 @@ StandardPasswordEncoderの設定例
          * - | (1)
            - | 環境変数:PASSWORD_ENCODER_SECRETから値を取得する。
 
+  .. note::
 
+    パスワードを\ ``StandardPasswordEncoder`` \によるハッシュ化によって管理する場合、すべてのパスワードがハッシュ化されている必要がある。
+    パスワードが平文で保存されているアカウントが存在し、そのアカウントで認証しようとした場合、例外メッセージに以下のような形でパスワードが出力されてしまうため注意が必要である。
+
+    \ ``java.lang.IllegalArgumentException: Non-hex character in input: (DB等で管理されている「平文パスワード」)`` \
 
   | Javaクラス例は\ ``BCryptPasswordEncoder``\ と同様のため、\ :ref:`BCryptPasswordEncoder`\ を参照されたい。
 


### PR DESCRIPTION
Please review #2092. Backport for 1.0.7.
