### PR TITLE
[5.3.x]Validation - Explanation of group validation is incorrect.  #2792

### DIFF
--- a/source/ArchitectureInDetail/WebApplicationDetail/Validation.rst
+++ b/source/ArchitectureInDetail/WebApplicationDetail/Validation.rst
@@ -1432,7 +1432,7 @@ Bean Validationでグループを指定する場合、アノテーションの\ 
      * - | (1)
        - | グループを振り分けるためのパラメータの条件を、\ ``param``\ 属性に追加する。
      * - | (2)
-       - | \ ``age``\ フィールドの\ ``@Min``\ 以外のアノテーションは、\ ``Default``\ グループに属しているため、\ ``Default``\ の指定も必要である。
+       - | \ ``@Min``\ 以外のアノテーションは、\ ``Default``\ グループに属しているため、\ ``Default``\ の指定も必要である。
 
 
 
@@ -1567,7 +1567,7 @@ Bean Validationでグループを指定する場合、アノテーションの\ 
                 @Min(value = 18, groups = Default.class), // (2)
                 @Min(value = 20, groups = Japanese.class),
                 @Min(value = 21, groups = Singaporean.class) })
-        @Max(200)
+        @Max(value = 200, groups = { Default.class, Japanese.class, Singaporean.class })
         private Integer age;
 
         @NotNull(groups = { Default.class, Japanese.class, Singaporean.class })
@@ -1586,7 +1586,7 @@ Bean Validationでグループを指定する場合、アノテーションの\ 
      * - 項番
        - 説明
      * - | (1)
-       - | \ ``age``\ フィールドの\ ``@Min``\ 以外のアノテーションにも、全グループを設定する。
+       - | \ ``@Min``\ 以外のアノテーションにも、全グループを設定する。
      * - | (2)
        - | \ ``Default``\ グループに対するルールを設定する。
 

--- a/source_en/ArchitectureInDetail/WebApplicationDetail/Validation.rst
+++ b/source_en/ArchitectureInDetail/WebApplicationDetail/Validation.rst
@@ -1555,7 +1555,7 @@ Rules are as follows.
                 @Min(value = 18, groups = Default.class), // (2)
                 @Min(value = 20, groups = Japanese.class),
                 @Min(value = 21, groups = Singaporean.class) })
-        @Max(200)
+        @Max(value = 200, groups = { Default.class, Japanese.class, Singaporean.class })
         private Integer age;
 
         @NotNull(groups = { Default.class, Japanese.class, Singaporean.class })


### PR DESCRIPTION
(cherry picked from commit a3076cf1d623719b62d08b64fd80c7c0998c0558)

Please review #2792 .

backport for 5.3.x.
