### PR TITLE
[5.4.x] Fixed Typo in Codelist.rst

### DIFF
--- a/source/ArchitectureInDetail/WebApplicationDetail/Codelist.rst
+++ b/source/ArchitectureInDetail/WebApplicationDetail/Codelist.rst
@@ -241,7 +241,7 @@ JSPでのコードリスト使用
 .. code-block:: html
 
   <select id="orderStatus" name="orderStatus">
-     <option value="">"--Select--</option>
+     <option value="">--Select--</option>
      <option value="1">Received</option>
      <option value="2">Sent</option>
      <option value="3">Cancelled</option>


### PR DESCRIPTION
(cherry picked from commit ef23af18a8e8a1a02257abf41ff643f3e92f87b8)

Please review #3234