### PR TITLE
[5.4.x] The TOC in TagLibAndELFunctions.rst has disappeared. #3172

### DIFF
--- a/source/ArchitectureInDetail/WebApplicationDetail/TagLibAndELFunctions.rst
+++ b/source/ArchitectureInDetail/WebApplicationDetail/TagLibAndELFunctions.rst
@@ -1,6 +1,12 @@
 共通ライブラリが提供するJSP Tag Library と EL Functions
 ================================================================================
 
+.. only:: html
+
+ .. contents:: 目次
+    :depth: 3
+    :local:
+
 .. _TagLibAndELFunctionsOverview:
 
 Overview


### PR DESCRIPTION
(cherry picked from commit f55f20b5f9f2999f74db0a478213c4dbd9f659b9)

Please review #3172 .

This PR is backport for 5.4.x .
